### PR TITLE
feat: implement GotoImplementation feature

### DIFF
--- a/vim/autoload/lsp_bridge.vim
+++ b/vim/autoload/lsp_bridge.vim
@@ -70,6 +70,15 @@ function! lsp_bridge#goto_type_definition() abort
     \ })
 endfunction
 
+function! lsp_bridge#goto_implementation() abort
+  call s:send_command({
+    \ 'command': 'goto_implementation',
+    \ 'file': expand('%:p'),
+    \ 'line': line('.') - 1,
+    \ 'column': col('.') - 1
+    \ })
+endfunction
+
 function! lsp_bridge#hover() abort
   call s:send_command({
     \ 'command': 'hover',
@@ -173,8 +182,8 @@ function! s:handle_response(channel, msg) abort
   elseif response.action == 'none'
     " 静默处理，不显示任何内容
   elseif response.action == 'error'
-    " 静默处理 "No definition found" 和 "No type definition found"
-    if response.message != 'No definition found' && response.message != 'No type definition found'
+    " 静默处理 "No definition found", "No type definition found", 和 "No implementation found"
+    if response.message != 'No definition found' && response.message != 'No type definition found' && response.message != 'No implementation found'
       echoerr response.message
     endif
   endif

--- a/vim/plugin/lsp_bridge.vim
+++ b/vim/plugin/lsp_bridge.vim
@@ -14,6 +14,7 @@ command! LspStart          call lsp_bridge#start()
 command! LspStop           call lsp_bridge#stop()
 command! LspDefinition     call lsp_bridge#goto_definition()
 command! LspTypeDefinition call lsp_bridge#goto_type_definition()
+command! LspImplementation call lsp_bridge#goto_implementation()
 command! LspHover          call lsp_bridge#hover()
 command! LspComplete       call lsp_bridge#complete()
 command! LspReferences     call lsp_bridge#references()
@@ -22,6 +23,7 @@ command! LspOpenLog        call lsp_bridge#open_log()
 " 默认快捷键
 nnoremap <silent> gd :LspDefinition<CR>
 nnoremap <silent> gy :LspTypeDefinition<CR>
+nnoremap <silent> gi :LspImplementation<CR>
 nnoremap <silent> gr :LspReferences<CR>
 nnoremap <silent> K  :LspHover<CR>
 


### PR DESCRIPTION
Implements GotoImplementation feature as requested in issue #6.

## Changes
- Add goto_implementation command to Rust binary using LSP textDocument/implementation
- Add :LspImplementation command and 'gi' key mapping to Vim plugin
- Follow existing patterns for goto_definition and goto_type_definition
- Add silent error handling for 'No implementation found' messages

## Usage
- Use `:LspImplementation` command or `gi` key mapping
- Jump to trait/interface implementations from definitions or usage sites

Fixes #6

Generated with [Claude Code](https://claude.ai/code)