### PR TITLE
feat: implement inlay hints functionality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,9 +151,27 @@ let g:lsp_bridge_auto_complete_min_chars = 1 " Minimum characters to trigger (de
 ### Default Key Mappings
 ```vim
 nnoremap <silent> gd :LspDefinition<CR>
+nnoremap <silent> gy :LspTypeDefinition<CR>
+nnoremap <silent> gi :LspImplementation<CR>
+nnoremap <silent> gr :LspReferences<CR>
 nnoremap <silent> K  :LspHover<CR>
 " Manual completion trigger
 inoremap <silent> <C-Space> <C-o>:LspComplete<CR>
+```
+
+### Available Commands
+```vim
+:LspStart              " Start LSP bridge process
+:LspStop               " Stop LSP bridge process
+:LspDefinition         " Jump to symbol definition
+:LspTypeDefinition     " Jump to type definition
+:LspImplementation     " Jump to implementation
+:LspHover              " Show hover information
+:LspComplete           " Trigger completion manually
+:LspReferences         " Find all references
+:LspInlayHints         " Show inlay hints for current file
+:LspClearInlayHints    " Clear displayed inlay hints
+:LspOpenLog            " Open LSP bridge log file
 ```
 
 ### Log Viewing Commands
@@ -180,6 +198,12 @@ inoremap <silent> <C-Space> <C-o>:LspComplete<CR>
   - **Confirmation**: Enter/Tab to accept, Esc to cancel
   - **Type-based colors**: Function=blue, Variable=green, etc.
   - **Match highlighting**: [brackets] around matching characters
+- `inlay_hints` command - Display inline type annotations and parameter names:
+  - **Type hints**: Show variable types (`: i32`) after declarations
+  - **Parameter hints**: Show parameter names (`count: 5`) in function calls  
+  - **Text properties**: Uses Vim 8.1+ text properties for optimal display
+  - **Fallback support**: Falls back to match highlighting for older Vim versions
+  - **Customizable styling**: Separate highlight groups for types and parameters
 - Auto-initialization on file open (`BufReadPost`/`BufNewFile` for `*.rs` files)
 - Silent "no definition found" handling
 - Workspace root detection for `rust-analyzer` (searches for `Cargo.toml`)

--- a/crates/lsp-bridge/src/lib.rs
+++ b/crates/lsp-bridge/src/lib.rs
@@ -35,6 +35,8 @@ pub enum VimAction {
     Completions { items: Vec<CompletionItem> },
     #[serde(rename = "references")]
     References { locations: Vec<ReferenceLocation> },
+    #[serde(rename = "inlay_hints")]
+    InlayHints { hints: Vec<InlayHint> },
     #[serde(rename = "none")]
     None,
     #[serde(rename = "error")]
@@ -54,6 +56,15 @@ pub struct ReferenceLocation {
     pub file: String,
     pub line: u32,   // 0-based
     pub column: u32, // 0-based
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct InlayHint {
+    pub line: u32,        // 0-based line number
+    pub column: u32,      // 0-based column position
+    pub label: String,    // The hint text to display
+    pub kind: String,     // "type" or "parameter" 
+    pub tooltip: Option<String>, // Optional tooltip text
 }
 
 // Using VimAction directly - no legacy support
@@ -107,6 +118,7 @@ impl LspBridge {
                 "hover" => self.handle_hover(client, &command).await,
                 "completion" => self.handle_completion(client, &command).await,
                 "references" => self.handle_references(client, &command).await,
+                "inlay_hints" => self.handle_inlay_hints(client, &command).await,
                 _ => VimAction::Error {
                     message: format!("Unknown command: {}", command.command),
                 },
@@ -523,6 +535,63 @@ impl LspBridge {
         }
     }
 
+    /// 处理inlay hints
+    async fn handle_inlay_hints(&self, client: &LspClient, command: &VimCommand) -> VimAction {
+        use lsp_types::{
+            InlayHintParams, Range, Position, TextDocumentIdentifier,
+        };
+
+        // 确保文件已打开
+        if let Err(e) = self.ensure_file_open(client, &command.file).await {
+            return VimAction::Error {
+                message: format!("Failed to open file: {}", e),
+            };
+        }
+
+        let uri = match lsp_types::Url::from_file_path(&command.file) {
+            Ok(uri) => uri,
+            Err(_) => {
+                return VimAction::Error {
+                    message: format!("Invalid file path: {}", command.file),
+                }
+            }
+        };
+
+        // Read file to get the total number of lines for the range
+        let line_count = match std::fs::read_to_string(&command.file) {
+            Ok(content) => content.lines().count() as u32,
+            Err(_) => 1000, // fallback to a reasonable default
+        };
+
+        let params = InlayHintParams {
+            text_document: TextDocumentIdentifier { uri },
+            range: Range {
+                start: Position { line: 0, character: 0 },
+                end: Position { line: line_count, character: 0 },
+            },
+            work_done_progress_params: Default::default(),
+        };
+
+        use lsp_types::request::InlayHintRequest;
+        match client.request::<InlayHintRequest>(params).await {
+            Ok(Some(hints)) => {
+                use tracing::debug;
+                debug!("Got LSP inlay hints result: {:?}", hints);
+                
+                let converted_hints: Vec<InlayHint> = hints
+                    .iter()
+                    .map(InlayHint::from)
+                    .collect();
+                    
+                VimAction::InlayHints { hints: converted_hints }
+            }
+            Ok(None) => VimAction::InlayHints { hints: vec![] },
+            Err(e) => VimAction::Error {
+                message: e.to_string(),
+            },
+        }
+    }
+
     /// 处理文件打开通知
     async fn handle_file_open(&self, client: &LspClient, command: &VimCommand) -> VimAction {
         // 确保文件已经打开（发送textDocument/didOpen）
@@ -816,5 +885,44 @@ impl From<lsp_types::Hover> for VimAction {
         };
 
         VimAction::ShowHover { content }
+    }
+}
+
+// Convert LSP InlayHint to our InlayHint
+impl From<&lsp_types::InlayHint> for InlayHint {
+    fn from(hint: &lsp_types::InlayHint) -> Self {
+        use lsp_types::InlayHintLabel;
+        
+        let label = match &hint.label {
+            InlayHintLabel::String(s) => s.clone(),
+            InlayHintLabel::LabelParts(parts) => {
+                parts.iter().map(|part| part.value.as_str()).collect::<Vec<_>>().join("")
+            }
+        };
+        
+        let kind = hint.kind.as_ref().map(|k| {
+            use lsp_types::InlayHintKind;
+            match k {
+                InlayHintKind::TYPE => "type",
+                InlayHintKind::PARAMETER => "parameter",
+                _ => "other",
+            }
+        }).unwrap_or("other").to_string();
+        
+        let tooltip = hint.tooltip.as_ref().map(|tooltip| {
+            use lsp_types::InlayHintTooltip;
+            match tooltip {
+                InlayHintTooltip::String(s) => s.clone(),
+                InlayHintTooltip::MarkupContent(markup) => markup.value.clone(),
+            }
+        });
+        
+        InlayHint {
+            line: hint.position.line,
+            column: hint.position.character,
+            label,
+            kind,
+            tooltip,
+        }
     }
 }

--- a/test_inlay_hints.rs
+++ b/test_inlay_hints.rs
@@ -1,0 +1,18 @@
+// Test file for inlay hints functionality
+use lsp_types::{InlayHintParams, InlayHintRequest, Range, Position, TextDocumentIdentifier};
+
+fn main() {
+    // Test that our types compile
+    let _params = InlayHintParams {
+        text_document: TextDocumentIdentifier { 
+            uri: lsp_types::Url::parse("file:///test.rs").unwrap() 
+        },
+        range: Range {
+            start: Position { line: 0, character: 0 },
+            end: Position { line: 10, character: 0 },
+        },
+        work_done_progress_params: Default::default(),
+    };
+    
+    println!("InlayHint types compile successfully!");
+}

--- a/vim/autoload/lsp_bridge.vim
+++ b/vim/autoload/lsp_bridge.vim
@@ -124,6 +124,15 @@ function! lsp_bridge#references() abort
     \ })
 endfunction
 
+function! lsp_bridge#inlay_hints() abort
+  call s:send_command({
+    \ 'command': 'inlay_hints',
+    \ 'file': expand('%:p'),
+    \ 'line': 0,
+    \ 'column': 0
+    \ })
+endfunction
+
 " 获取当前光标位置的词前缀
 function! s:get_current_word_prefix() abort
   let line = getline('.')
@@ -179,6 +188,8 @@ function! s:handle_response(channel, msg) abort
     call s:show_completions(response.items)
   elseif response.action == 'references'
     call s:show_references(response.locations)
+  elseif response.action == 'inlay_hints'
+    call s:show_inlay_hints(response.hints)
   elseif response.action == 'none'
     " 静默处理，不显示任何内容
   elseif response.action == 'error'
@@ -546,6 +557,96 @@ function! lsp_bridge#open_log() abort
   
   execute 'split ' . fnameescape(s:log_file)
 endfunction
+
+" === Inlay Hints 功能 ===
+
+" 存储当前buffer的inlay hints
+let s:inlay_hints = {}
+
+" 显示inlay hints
+function! s:show_inlay_hints(hints) abort
+  " 清除当前buffer的旧hints
+  call s:clear_inlay_hints()
+  
+  if empty(a:hints)
+    echo "No inlay hints available"
+    return
+  endif
+  
+  " 存储hints并显示
+  let s:inlay_hints[bufnr('%')] = a:hints
+  call s:render_inlay_hints()
+  
+  echo 'Showing ' . len(a:hints) . ' inlay hints'
+endfunction
+
+" 清除inlay hints
+function! s:clear_inlay_hints() abort
+  let bufnr = bufnr('%')
+  if has_key(s:inlay_hints, bufnr)
+    " 清除所有匹配项
+    call clearmatches()
+    unlet s:inlay_hints[bufnr]
+  endif
+endfunction
+
+" 公开接口：清除inlay hints
+function! lsp_bridge#clear_inlay_hints() abort
+  call s:clear_inlay_hints()
+  echo 'Inlay hints cleared'
+endfunction
+
+" 渲染inlay hints到buffer
+function! s:render_inlay_hints() abort
+  let bufnr = bufnr('%')
+  if !has_key(s:inlay_hints, bufnr)
+    return
+  endif
+  
+  " 定义highlight组
+  if !hlexists('InlayHintType')
+    highlight InlayHintType ctermfg=8 ctermbg=NONE gui=italic guifg=#888888 guibg=NONE
+  endif
+  if !hlexists('InlayHintParameter')
+    highlight InlayHintParameter ctermfg=6 ctermbg=NONE gui=italic guifg=#008080 guibg=NONE
+  endif
+  
+  " 为每个hint添加virtual text（如果支持的话）
+  for hint in s:inlay_hints[bufnr]
+    let line_num = hint.line + 1  " Convert to 1-based
+    let col_num = hint.column + 1
+    let text = hint.label
+    let hl_group = hint.kind == 'type' ? 'InlayHintType' : 'InlayHintParameter'
+    
+    " 使用文本属性（Vim 8.1+）显示inlay hints
+    if exists('*prop_type_add')
+      " 确保属性类型存在
+      try
+        call prop_type_add('inlay_hint_' . hint.kind, {'highlight': hl_group})
+      catch /E969/
+        " 属性类型已存在，忽略错误
+      endtry
+      
+      " 添加文本属性
+      try
+        call prop_add(line_num, col_num, {
+          \ 'type': 'inlay_hint_' . hint.kind,
+          \ 'text': text,
+          \ 'bufnr': bufnr
+          \ })
+      catch
+        " 添加失败，可能是位置无效
+      endtry
+    else
+      " 降级到使用matchaddpos（不如text properties好，但总比没有强）
+      let pattern = '\%' . line_num . 'l\%' . col_num . 'c'
+      call matchadd(hl_group, pattern)
+    endif
+  endfor
+endfunction
+
+" 清除所有inlay hints命令
+command! LspClearInlayHints call s:clear_inlay_hints()
 
 
 

--- a/vim/plugin/lsp_bridge.vim
+++ b/vim/plugin/lsp_bridge.vim
@@ -18,6 +18,8 @@ command! LspImplementation call lsp_bridge#goto_implementation()
 command! LspHover          call lsp_bridge#hover()
 command! LspComplete       call lsp_bridge#complete()
 command! LspReferences     call lsp_bridge#references()
+command! LspInlayHints     call lsp_bridge#inlay_hints()
+command! LspClearInlayHints call lsp_bridge#clear_inlay_hints()
 command! LspOpenLog        call lsp_bridge#open_log()
 
 " 默认快捷键


### PR DESCRIPTION
Implements inlay hints functionality as requested in issue #8.

Adds LSP inlay hints support with inline type annotations and parameter names:

- Add InlayHint struct and VimAction::InlayHints variant
- Implement handle_inlay_hints method in Rust bridge
- Add :LspInlayHints and :LspClearInlayHints commands
- Support Vim 8.1+ text properties with fallback to match highlighting
- Add customizable highlight groups for type and parameter hints
- Update documentation with new commands and features

Supports rust-analyzer inlay hints for improved code readability.

Closes #8

Generated with [Claude Code](https://claude.ai/code)