### PR TITLE
feat: implement textDocument/declaration support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ vim -u vimrc test_data/src/lib.rs
 
 # Test other features:
 # - Press 'K' for hover information
+# - Press 'gD' for goto declaration
 # - Use :LspComplete for completion
 ```
 
@@ -102,7 +103,7 @@ The system uses a simplified Command-Action protocol (v0.2):
 **Vim → lsp-bridge (Commands):**
 ```json
 {
-  "command": "goto_definition",
+  "command": "goto_definition", // or "goto_declaration"
   "file": "/absolute/path/to/file.rs",
   "line": 31,    // 0-based
   "column": 26   // 0-based
@@ -151,6 +152,7 @@ let g:lsp_bridge_auto_complete_min_chars = 1 " Minimum characters to trigger (de
 ### Default Key Mappings
 ```vim
 nnoremap <silent> gd :LspDefinition<CR>
+nnoremap <silent> gD :LspDeclaration<CR>
 nnoremap <silent> gy :LspTypeDefinition<CR>
 nnoremap <silent> gi :LspImplementation<CR>
 nnoremap <silent> gr :LspReferences<CR>
@@ -164,6 +166,7 @@ inoremap <silent> <C-Space> <C-o>:LspComplete<CR>
 :LspStart              " Start LSP bridge process
 :LspStop               " Stop LSP bridge process
 :LspDefinition         " Jump to symbol definition
+:LspDeclaration        " Jump to symbol declaration
 :LspTypeDefinition     " Jump to type definition
 :LspImplementation     " Jump to implementation
 :LspHover              " Show hover information
@@ -189,6 +192,7 @@ inoremap <silent> <C-Space> <C-o>:LspComplete<CR>
 ### Implemented Features ✅
 - `file_open` command - Initialize file in LSP server
 - `goto_definition` command - Jump to symbol definitions with popup window display
+- `goto_declaration` command - Jump to symbol declarations with popup window display
 - `hover` command - Show documentation/type information in floating popup  
 - `completion` command - Advanced code completion with:
   - **Auto-trigger**: Automatically shows completions while typing (300ms delay)
@@ -205,7 +209,7 @@ inoremap <silent> <C-Space> <C-o>:LspComplete<CR>
   - **Fallback support**: Falls back to match highlighting for older Vim versions
   - **Customizable styling**: Separate highlight groups for types and parameters
 - Auto-initialization on file open (`BufReadPost`/`BufNewFile` for `*.rs` files)
-- Silent "no definition found" handling
+- Silent "no definition found" and "no declaration found" handling
 - Workspace root detection for `rust-analyzer` (searches for `Cargo.toml`)
 - Popup window support for Vim 8.1+
 
@@ -239,9 +243,11 @@ vim -u vimrc
 # 1. Open test_data/src/lib.rs  
 # 2. Navigate to User::new usage
 # 3. Press 'gd' to jump to definition
+# 4. Press 'gD' to jump to declaration
 
 # Run automated Vim integration tests:
 vim -u vimrc -c 'source tests/vim/goto_definition.vim'
+vim -u vimrc -c 'source tests/vim/declaration_test.vim'
 vim -u vimrc -c 'source tests/vim/completion_test.vim'
 
 # Auto-completion testing (manual only):

--- a/crates/lsp-bridge/src/lib.rs
+++ b/crates/lsp-bridge/src/lib.rs
@@ -113,6 +113,7 @@ impl LspBridge {
             match command.command.as_str() {
                 "file_open" => self.handle_file_open(client, &command).await,
                 "goto_definition" => self.handle_goto_definition(client, &command).await,
+                "goto_declaration" => self.handle_goto_declaration(client, &command).await,
                 "goto_type_definition" => self.handle_goto_type_definition(client, &command).await,
                 "goto_implementation" => self.handle_goto_implementation(client, &command).await,
                 "hover" => self.handle_hover(client, &command).await,
@@ -127,6 +128,80 @@ impl LspBridge {
             VimAction::Error {
                 message: "No LSP client available".to_string(),
             }
+        }
+    }
+
+    /// 处理跳转到声明
+    async fn handle_goto_declaration(&self, client: &LspClient, command: &VimCommand) -> VimAction {
+        use lsp_types::{
+            DeclarationParams, Position, TextDocumentIdentifier, TextDocumentPositionParams,
+        };
+
+        // 确保文件已打开
+        if let Err(e) = self.ensure_file_open(client, &command.file).await {
+            return VimAction::Error {
+                message: format!("Failed to open file: {}", e),
+            };
+        }
+
+        let uri = match lsp_types::Url::from_file_path(&command.file) {
+            Ok(uri) => uri,
+            Err(_) => {
+                return VimAction::Error {
+                    message: format!("Invalid file path: {}", command.file),
+                }
+            }
+        };
+
+        let params = DeclarationParams {
+            text_document_position_params: TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier { uri },
+                position: Position {
+                    line: command.line,
+                    character: command.column,
+                },
+            },
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+        };
+
+        use lsp_types::request::GotoDeclaration;
+        match client.request::<GotoDeclaration>(params).await {
+            Ok(Some(response)) => {
+                use tracing::debug;
+                debug!("Got LSP declaration response: {:?}", response);
+
+                // 处理 GotoDefinitionResponse (可能是 Location 或 LocationLink)
+                match response {
+                    lsp_types::GotoDefinitionResponse::Scalar(location) => {
+                        VimAction::from(location)
+                    }
+                    lsp_types::GotoDefinitionResponse::Array(locations) => {
+                        if let Some(first) = locations.first() {
+                            VimAction::from(first)
+                        } else {
+                            VimAction::Error {
+                                message: "No declaration found".to_string(),
+                            }
+                        }
+                    }
+                    lsp_types::GotoDefinitionResponse::Link(links) => {
+                        if let Some(first_link) = links.first() {
+                            VimAction::from(first_link)
+                        } else {
+                            VimAction::Error {
+                                message: "No declaration found".to_string(),
+                            }
+                        }
+                    }
+                }
+            }
+            Ok(None) => VimAction::Error {
+                message: "No declaration found".to_string(),
+            },
+            Err(e) => VimAction::Error {
+                message: e.to_string(),
+            },
         }
     }
 

--- a/crates/lsp-bridge/src/lib.rs
+++ b/crates/lsp-bridge/src/lib.rs
@@ -134,7 +134,7 @@ impl LspBridge {
     /// 处理跳转到声明
     async fn handle_goto_declaration(&self, client: &LspClient, command: &VimCommand) -> VimAction {
         use lsp_types::{
-            DeclarationParams, Position, TextDocumentIdentifier, TextDocumentPositionParams,
+            Position, TextDocumentIdentifier, TextDocumentPositionParams,
         };
 
         // 确保文件已打开
@@ -153,16 +153,12 @@ impl LspBridge {
             }
         };
 
-        let params = DeclarationParams {
-            text_document_position_params: TextDocumentPositionParams {
-                text_document: TextDocumentIdentifier { uri },
-                position: Position {
-                    line: command.line,
-                    character: command.column,
-                },
+        let params = TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier { uri },
+            position: Position {
+                line: command.line,
+                character: command.column,
             },
-            work_done_progress_params: Default::default(),
-            partial_result_params: Default::default(),
         };
 
         use lsp_types::request::GotoDeclaration;

--- a/crates/lsp-bridge/src/lib.rs
+++ b/crates/lsp-bridge/src/lib.rs
@@ -134,7 +134,7 @@ impl LspBridge {
     /// 处理跳转到声明
     async fn handle_goto_declaration(&self, client: &LspClient, command: &VimCommand) -> VimAction {
         use lsp_types::{
-            Position, TextDocumentIdentifier, TextDocumentPositionParams,
+            GotoDefinitionParams, Position, TextDocumentIdentifier, TextDocumentPositionParams,
         };
 
         // 确保文件已打开
@@ -153,12 +153,16 @@ impl LspBridge {
             }
         };
 
-        let params = TextDocumentPositionParams {
-            text_document: TextDocumentIdentifier { uri },
-            position: Position {
-                line: command.line,
-                character: command.column,
+        let params = GotoDefinitionParams {
+            text_document_position_params: TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier { uri },
+                position: Position {
+                    line: command.line,
+                    character: command.column,
+                },
             },
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
         };
 
         use lsp_types::request::GotoDeclaration;

--- a/tests/vim/declaration_test.vim
+++ b/tests/vim/declaration_test.vim
@@ -1,0 +1,19 @@
+" Test for goto declaration functionality
+" This test follows the same pattern as goto_definition.vim
+
+" Test script to verify declaration functionality
+echo "Testing LspDeclaration functionality"
+
+" Open test file 
+e test_data/src/lib.rs
+
+" Navigate to a location where declaration might be useful
+" For Rust, this would typically be jumping from implementation to trait declaration
+call cursor(31, 26)
+
+" Call the declaration command
+LspDeclaration
+
+echo "Declaration test completed - check if it jumps correctly"
+echo "Expected: Jump to trait/interface declaration if available"
+echo "Key binding test: Press gD to test key mapping"

--- a/vim/autoload/lsp_bridge.vim
+++ b/vim/autoload/lsp_bridge.vim
@@ -61,6 +61,15 @@ function! lsp_bridge#goto_definition() abort
     \ })
 endfunction
 
+function! lsp_bridge#goto_declaration() abort
+  call s:send_command({
+    \ 'command': 'goto_declaration',
+    \ 'file': expand('%:p'),
+    \ 'line': line('.') - 1,
+    \ 'column': col('.') - 1
+    \ })
+endfunction
+
 function! lsp_bridge#goto_type_definition() abort
   call s:send_command({
     \ 'command': 'goto_type_definition',
@@ -193,8 +202,8 @@ function! s:handle_response(channel, msg) abort
   elseif response.action == 'none'
     " 静默处理，不显示任何内容
   elseif response.action == 'error'
-    " 静默处理 "No definition found", "No type definition found", 和 "No implementation found"
-    if response.message != 'No definition found' && response.message != 'No type definition found' && response.message != 'No implementation found'
+    " 静默处理 "No definition found", "No declaration found", "No type definition found", 和 "No implementation found"
+    if response.message != 'No definition found' && response.message != 'No declaration found' && response.message != 'No type definition found' && response.message != 'No implementation found'
       echoerr response.message
     endif
   endif

--- a/vim/plugin/lsp_bridge.vim
+++ b/vim/plugin/lsp_bridge.vim
@@ -13,6 +13,7 @@ let g:lsp_bridge_command = get(g:, 'lsp_bridge_command', ['lsp-bridge'])
 command! LspStart          call lsp_bridge#start()
 command! LspStop           call lsp_bridge#stop()
 command! LspDefinition     call lsp_bridge#goto_definition()
+command! LspDeclaration    call lsp_bridge#goto_declaration()
 command! LspTypeDefinition call lsp_bridge#goto_type_definition()
 command! LspImplementation call lsp_bridge#goto_implementation()
 command! LspHover          call lsp_bridge#hover()
@@ -24,6 +25,7 @@ command! LspOpenLog        call lsp_bridge#open_log()
 
 " 默认快捷键
 nnoremap <silent> gd :LspDefinition<CR>
+nnoremap <silent> gD :LspDeclaration<CR>
 nnoremap <silent> gy :LspTypeDefinition<CR>
 nnoremap <silent> gi :LspImplementation<CR>
 nnoremap <silent> gr :LspReferences<CR>


### PR DESCRIPTION
Implements LSP textDocument/declaration functionality as requested in issue #10.

## Changes
- Add handle_goto_declaration method in lsp-bridge
- Add LspDeclaration command and gD key mapping
- Update error handling to silently handle "No declaration found"
- Add basic test for declaration functionality

## Usage
```vim
:LspDeclaration  # Command
gD               # Key mapping
```

Closes #10

Generated with [Claude Code](https://claude.ai/code)