### PR TITLE
feat: implement LSP call hierarchy functionality

### DIFF
--- a/vim/plugin/lsp_bridge.vim
+++ b/vim/plugin/lsp_bridge.vim
@@ -22,6 +22,8 @@ command! LspReferences     call lsp_bridge#references()
 command! LspInlayHints     call lsp_bridge#inlay_hints()
 command! LspClearInlayHints call lsp_bridge#clear_inlay_hints()
 command! -nargs=? LspRename call lsp_bridge#rename(<args>)
+command! LspCallHierarchyIncoming call lsp_bridge#call_hierarchy_incoming()
+command! LspCallHierarchyOutgoing call lsp_bridge#call_hierarchy_outgoing()
 command! LspOpenLog        call lsp_bridge#open_log()
 
 " 默认快捷键
@@ -32,6 +34,8 @@ nnoremap <silent> gi :LspImplementation<CR>
 nnoremap <silent> gr :LspReferences<CR>
 nnoremap <silent> K  :LspHover<CR>
 nnoremap <silent> <leader>rn :LspRename<CR>
+nnoremap <silent> <leader>ci :LspCallHierarchyIncoming<CR>
+nnoremap <silent> <leader>co :LspCallHierarchyOutgoing<CR>
 
 " 简单的文件初始化
 if get(g:, 'lsp_bridge_auto_start', 1)


### PR DESCRIPTION
Add support for callHierarchy/incomingCalls and callHierarchy/outgoingCalls:

- Added CallHierarchyItem type and call_hierarchy action to VimAction enum
- Implemented handle_call_hierarchy_incoming/outgoing in Rust bridge
- Added prepare_call_hierarchy, get_incoming_calls, get_outgoing_calls methods
- Added LSP CallHierarchy protocol support with proper error handling
- Added Vim commands: LspCallHierarchyIncoming, LspCallHierarchyOutgoing
- Added key mappings: <leader>ci (incoming), <leader>co (outgoing)
- Results displayed in quickfix list with function names and details
- Follows existing code patterns and maintains project architecture

Fixes #16

Generated with [Claude Code](https://claude.ai/code)