### PR TITLE
feat: implement textDocument/documentSymbol LSP feature

### DIFF
--- a/vim/plugin/lsp_bridge.vim
+++ b/vim/plugin/lsp_bridge.vim
@@ -24,6 +24,7 @@ command! LspClearInlayHints call lsp_bridge#clear_inlay_hints()
 command! -nargs=? LspRename call lsp_bridge#rename(<args>)
 command! LspCallHierarchyIncoming call lsp_bridge#call_hierarchy_incoming()
 command! LspCallHierarchyOutgoing call lsp_bridge#call_hierarchy_outgoing()
+command! LspDocumentSymbols call lsp_bridge#document_symbols()
 command! LspOpenLog        call lsp_bridge#open_log()
 
 " 默认快捷键
@@ -36,6 +37,7 @@ nnoremap <silent> K  :LspHover<CR>
 nnoremap <silent> <leader>rn :LspRename<CR>
 nnoremap <silent> <leader>ci :LspCallHierarchyIncoming<CR>
 nnoremap <silent> <leader>co :LspCallHierarchyOutgoing<CR>
+nnoremap <silent> <leader>s :LspDocumentSymbols<CR>
 
 " 简单的文件初始化
 if get(g:, 'lsp_bridge_auto_start', 1)


### PR DESCRIPTION
Add documentSymbol functionality to yac.vim LSP bridge:

- Add DocumentSymbol struct with hierarchical children support
- Support both flat (SymbolInformation) and nested (DocumentSymbol) LSP responses
- Add document_symbols command handler in Rust lsp-bridge
- Add :LspDocumentSymbols Vim command with <leader>s keybinding
- Display symbols in quickfix list with proper hierarchical indentation
- Handle nested symbols (structs with methods, modules with functions, etc.)

Generated with [Claude Code](https://claude.ai/code)