### PR TITLE
refactor: apply Linus-style principles to lsp-bridge and lsp-client

### DIFF
--- a/crates/lsp-bridge/src/lib.rs
+++ b/crates/lsp-bridge/src/lib.rs
@@ -183,11 +183,36 @@ impl FilePos {
         }
     }
 
+    /// Linus 风格：统一的参数构造，消除重复模式
     pub fn to_goto_definition_params(
         &self,
         uri: lsp_types::Url,
     ) -> lsp_types::GotoDefinitionParams {
         lsp_types::GotoDefinitionParams {
+            text_document_position_params: self.to_text_document_position_params(uri),
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+        }
+    }
+
+    /// Linus 风格：复用 goto_definition_params 的结构
+    pub fn to_goto_type_definition_params(
+        &self,
+        uri: lsp_types::Url,
+    ) -> lsp_types::request::GotoTypeDefinitionParams {
+        lsp_types::request::GotoTypeDefinitionParams {
+            text_document_position_params: self.to_text_document_position_params(uri),
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+        }
+    }
+
+    /// Linus 风格：复用 goto_definition_params 的结构
+    pub fn to_goto_implementation_params(
+        &self,
+        uri: lsp_types::Url,
+    ) -> lsp_types::request::GotoImplementationParams {
+        lsp_types::request::GotoImplementationParams {
             text_document_position_params: self.to_text_document_position_params(uri),
             work_done_progress_params: Default::default(),
             partial_result_params: Default::default(),
@@ -495,23 +520,13 @@ impl LspBridge {
             }
             "type_definition" => {
                 use lsp_types::request::GotoTypeDefinition;
-                let type_params = lsp_types::request::GotoTypeDefinitionParams {
-                    text_document_position_params: pos
-                        .to_text_document_position_params(uri.clone()),
-                    work_done_progress_params: Default::default(),
-                    partial_result_params: Default::default(),
-                };
-                client.request::<GotoTypeDefinition>(type_params).await
+                let params = pos.to_goto_type_definition_params(uri.clone());
+                client.request::<GotoTypeDefinition>(params).await
             }
             "implementation" => {
                 use lsp_types::request::GotoImplementation;
-                let impl_params = lsp_types::request::GotoImplementationParams {
-                    text_document_position_params: pos
-                        .to_text_document_position_params(uri.clone()),
-                    work_done_progress_params: Default::default(),
-                    partial_result_params: Default::default(),
-                };
-                client.request::<GotoImplementation>(impl_params).await
+                let params = pos.to_goto_implementation_params(uri.clone());
+                client.request::<GotoImplementation>(params).await
             }
             _ => {
                 return VimAction::Error {


### PR DESCRIPTION
This PR applies Linus Torvalds' engineering philosophy to refactor lsp-bridge and lsp-client components.

## Key Changes
- Eliminated deep nesting in main.rs following the "3-layer indentation" principle
- Unified error handling patterns to reduce code duplication
- Optimized FilePos parameter conversion methods to eliminate special cases
- Simplified tokio::select! branch logic
- Maintained code size constraint (~800 lines)

## Analysis Results
1. **lsp-types complexity**: Necessary complexity for protocol boundary layer
2. **Data structures**: Well-designed with good taste principles

Generated with [Claude Code](https://claude.ai/code)