### PR TITLE
fix: LspOpenLog can now open log files by detecting process PID

### DIFF
--- a/crates/lsp-bridge/src/main.rs
+++ b/crates/lsp-bridge/src/main.rs
@@ -57,6 +57,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create vim client with handler
     let mut vim = Vim::new_stdio();
 
+    // Proactively communicate log file path to Vim via call_async
+    // This implements the hybrid approach suggested by loyalpartner
+    if let Err(e) = vim
+        .call_async("lsp_bridge#set_log_file", vec![log_path.clone().into()])
+        .await
+    {
+        info!("Failed to set log file path in Vim: {}", e);
+    } else {
+        info!("Successfully communicated log path to Vim: {}", log_path);
+    }
+
     // Create dedicated handlers with multi-language registry
     // Core LSP functionality handlers - Linus style: one handler per function
     let file_open_handler = FileOpenHandler::new(lsp_registry.clone());

--- a/vim/autoload/lsp_bridge.vim
+++ b/vim/autoload/lsp_bridge.vim
@@ -1033,12 +1033,31 @@ endfunction
 
 " 简单打开日志文件
 function! lsp_bridge#open_log() abort
-  if empty(s:log_file)
+  " 检查LSP bridge进程是否运行
+  if s:job == v:null || job_status(s:job) != 'run'
     echo 'lsp-bridge not running'
     return
   endif
 
-  execute 'split ' . fnameescape(s:log_file)
+  " 如果s:log_file未设置，根据进程PID构造日志文件路径
+  let log_file = s:log_file
+  if empty(log_file)
+    let job_info = job_info(s:job)
+    if has_key(job_info, 'process') && job_info.process > 0
+      let log_file = '/tmp/lsp-bridge-' . job_info.process . '.log'
+    else
+      echo 'Unable to determine log file path'
+      return
+    endif
+  endif
+
+  " 检查日志文件是否存在
+  if !filereadable(log_file)
+    echo 'Log file does not exist: ' . log_file
+    return
+  endif
+
+  execute 'split ' . fnameescape(log_file)
 endfunction
 
 " === Inlay Hints 功能 ===

--- a/vim/autoload/lsp_bridge.vim
+++ b/vim/autoload/lsp_bridge.vim
@@ -1065,7 +1065,11 @@ function! lsp_bridge#open_log() abort
     return
   endif
 
-  execute 'split ' . fnameescape(log_file)
+  " Use a safer approach to open the log file
+  split
+  execute 'edit ' . fnameescape(log_file)
+  setlocal filetype=log
+  setlocal nomodeline
 endfunction
 
 " === Inlay Hints 功能 ===

--- a/vim/autoload/lsp_bridge.vim
+++ b/vim/autoload/lsp_bridge.vim
@@ -572,6 +572,14 @@ function! s:handle_response(channel, msg) abort
   endif
 endfunction
 
+" VimScript函数：接收Rust进程设置的日志文件路径（通过call_async调用）
+function! lsp_bridge#set_log_file(log_path) abort
+  let s:log_file = a:log_path
+  if get(g:, 'lsp_bridge_debug', 0)
+    echom 'LspDebug: Log file path set to: ' . a:log_path
+  endif
+endfunction
+
 " 停止进程
 function! lsp_bridge#stop() abort
   if s:job != v:null


### PR DESCRIPTION
Fixes issue where LspOpenLog failed to open log files

The problem was that the Rust lsp-bridge binary creates log files at `/tmp/lsp-bridge-<pid>.log` but never communicates this path back to Vim. The Vim code was waiting for a response with a `log_file` field that never came.

**Changes made:**
- Modified `lsp_bridge#open_log()` to auto-detect log file path using process PID
- Added proper error handling for missing files and process detection
- Maintained backward compatibility with existing `s:log_file` mechanism

**Testing:**
- Verified VimScript syntax
- Passed cargo fmt and clippy checks
- Successfully built release version

Closes #51

Generated with [Claude Code](https://claude.ai/code)