### PR TITLE
refactor: 重构 Cargo.toml 为 workspace 结构

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,31 @@
 members = ["crates/lsp-client", "crates/lsp-bridge", "crates/vim", "test_data"]
 resolver = "2"
 
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+authors = ["LSP Bridge Team"]
+license = "MIT"
+
+[workspace.dependencies]
+# Internal dependencies
+lsp-client = { path = "crates/lsp-client" }
+vim = { path = "crates/vim" }
+
+# External dependencies
+lsp-types = "0.94"
+tokio = { version = "1.35", features = ["full"] }
+tokio-test = "0.4"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tracing = "0.1"
+tracing-subscriber = "0.3"
+async-trait = "0.1"
+anyhow = "1.0"
+thiserror = "1.0"
+bytes = "1.5"
+tempfile = "3.8"
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/crates/lsp-bridge/Cargo.toml
+++ b/crates/lsp-bridge/Cargo.toml
@@ -1,24 +1,25 @@
 [package]
 name = "lsp-bridge"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
 
 [[bin]]
 name = "lsp-bridge"
 path = "src/main.rs"
 
-
 [dependencies]
-lsp-client = { path = "../lsp-client" }
-lsp-types = "0.94"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-tokio = { version = "1.0", features = ["full"] }
-tracing = "0.1"
-tracing-subscriber = "0.3"
-vim = { path = "../vim" }
-async-trait = "0.1"
-anyhow = "1.0"
+lsp-client.workspace = true
+lsp-types.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+vim.workspace = true
+async-trait.workspace = true
+anyhow.workspace = true
 
 [dev-dependencies]
-tokio-test = "0.4"
+tokio-test.workspace = true

--- a/crates/lsp-client/Cargo.toml
+++ b/crates/lsp-client/Cargo.toml
@@ -1,36 +1,36 @@
 [package]
 name = "lsp-client"
-version = "0.1.0"
-edition = "2021"
-authors = ["LSP Bridge Team"]
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
 description = "LSP client implementation with protocol type support"
-license = "MIT"
 
 [dependencies]
 # LSP protocol types
-lsp-types = "0.94"
+lsp-types.workspace = true
 
 # Async runtime
-tokio = { version = "1.35", features = ["full", "process"] }
+tokio = { workspace = true, features = ["process"] }
 
 # JSON and serialization
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde.workspace = true
+serde_json.workspace = true
 
 # Error handling
-thiserror = "1.0"
+thiserror.workspace = true
 
 # Logging
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", optional = true }
+tracing.workspace = true
+tracing-subscriber = { workspace = true, optional = true }
 
 # Networking and IO
-bytes = "1.5"
+bytes.workspace = true
 
 [dev-dependencies]
-tokio-test = "0.4"
-tempfile = "3.8"
-tracing-subscriber = "0.3"
+tokio-test.workspace = true
+tempfile.workspace = true
+tracing-subscriber.workspace = true
 
 [[example]]
 name = "goto_definition"

--- a/crates/vim/Cargo.toml
+++ b/crates/vim/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
 name = "vim"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
 
 [dependencies]
-async-trait = "0.1"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-tokio = { version = "1.0", features = ["full"] }
-anyhow = "1.0"
-tracing = "0.1"
+async-trait.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+anyhow.workspace = true
+tracing.workspace = true


### PR DESCRIPTION
This PR refactors the project to use Cargo workspace structure for centralized dependency and version management.

## Changes
- Added `[workspace.package]` and `[workspace.dependencies]` sections to root Cargo.toml
- Unified all crate versions to 0.1.0
- Centralized external dependency version management
- Fixed tokio version inconsistency (unified to 1.35)
- All crates now inherit workspace configuration

## Benefits
- Eliminates duplicate dependency declarations
- Ensures consistent versions across all crates
- Simplifies dependency updates
- Maintains crate-specific features and configurations

Closes #54

Generated with [Claude Code](https://claude.ai/code)