### PR TITLE
feat: convert LSP lifecycle methods to use notifications

### DIFF
--- a/crates/lsp-bridge/src/handlers/did_change.rs
+++ b/crates/lsp-bridge/src/handlers/did_change.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use lsp_bridge::LspRegistry;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::sync::Arc;
 use tracing::debug;
 use vim::Handler;
@@ -29,19 +29,8 @@ pub struct Range {
     pub end_column: u32,
 }
 
-#[derive(Debug, Serialize)]
-pub struct DidChangeResult {
-    pub success: bool,
-}
-
-// Linus-style: DidChangeResult 要么完整存在，要么不存在
-pub type DidChangeResponse = Option<DidChangeResult>;
-
-impl DidChangeResult {
-    pub fn new(success: bool) -> Self {
-        Self { success }
-    }
-}
+// Notification pattern - no response data needed
+pub type DidChangeResponse = Option<()>;
 
 impl Range {
     pub fn to_lsp_range(&self) -> lsp_types::Range {
@@ -93,7 +82,7 @@ impl Handler for DidChangeHandler {
         // Detect language
         let language = match self.lsp_registry.detect_language(&input.file) {
             Some(lang) => lang,
-            None => return Ok(Some(Some(DidChangeResult::new(false)))), // Unsupported file type
+            None => return Ok(None), // Unsupported file type - notification ignores errors
         };
 
         // Ensure client exists
@@ -103,13 +92,13 @@ impl Handler for DidChangeHandler {
             .await
             .is_err()
         {
-            return Ok(Some(Some(DidChangeResult::new(false))));
+            return Ok(None); // No client available - notification ignores errors
         }
 
         // Convert file path to URI
         let uri = match super::common::file_path_to_uri(&input.file) {
             Ok(uri) => uri,
-            Err(_) => return Ok(Some(Some(DidChangeResult::new(false)))), // 处理了请求，但转换失败
+            Err(_) => return Ok(None), // URI conversion failed - notification ignores errors
         };
 
         // Convert changes to LSP format
@@ -139,11 +128,11 @@ impl Handler for DidChangeHandler {
                     "DidChange notification sent for: {} (version {})",
                     input.file, input.version
                 );
-                Ok(Some(Some(DidChangeResult::new(true))))
+                Ok(None) // Notification pattern - no response needed
             }
             Err(e) => {
                 debug!("DidChange notification failed: {:?}", e);
-                Ok(Some(Some(DidChangeResult::new(false))))
+                Ok(None) // Notification pattern - ignore errors
             }
         }
     }

--- a/crates/lsp-bridge/src/handlers/did_save.rs
+++ b/crates/lsp-bridge/src/handlers/did_save.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use lsp_bridge::LspRegistry;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::sync::Arc;
 use tracing::debug;
 use vim::Handler;
@@ -13,19 +13,8 @@ pub struct DidSaveRequest {
     pub text: Option<String>, // Full document text (if server supports it)
 }
 
-#[derive(Debug, Serialize)]
-pub struct DidSaveResult {
-    pub success: bool,
-}
-
-// Linus-style: DidSaveResult 要么完整存在，要么不存在
-pub type DidSaveResponse = Option<DidSaveResult>;
-
-impl DidSaveResult {
-    pub fn new(success: bool) -> Self {
-        Self { success }
-    }
-}
+// Notification pattern - no response data needed
+pub type DidSaveResponse = Option<()>;
 
 pub struct DidSaveHandler {
     lsp_registry: Arc<LspRegistry>,
@@ -52,7 +41,7 @@ impl Handler for DidSaveHandler {
         // Detect language
         let language = match self.lsp_registry.detect_language(&input.file) {
             Some(lang) => lang,
-            None => return Ok(Some(Some(DidSaveResult::new(false)))), // Unsupported file type
+            None => return Ok(None), // Unsupported file type - notification ignores errors
         };
 
         // Ensure client exists
@@ -62,13 +51,13 @@ impl Handler for DidSaveHandler {
             .await
             .is_err()
         {
-            return Ok(Some(Some(DidSaveResult::new(false))));
+            return Ok(None); // No client available - notification ignores errors
         }
 
         // Convert file path to URI
         let uri = match super::common::file_path_to_uri(&input.file) {
             Ok(uri) => uri,
-            Err(_) => return Ok(Some(Some(DidSaveResult::new(false)))), // 处理了请求，但转换失败
+            Err(_) => return Ok(None), // URI conversion failed - notification ignores errors
         };
 
         // Send LSP didSave notification
@@ -87,11 +76,11 @@ impl Handler for DidSaveHandler {
         {
             Ok(_) => {
                 debug!("DidSave notification sent for: {}", input.file);
-                Ok(Some(Some(DidSaveResult::new(true))))
+                Ok(None) // Notification pattern - no response needed
             }
             Err(e) => {
                 debug!("DidSave notification failed: {:?}", e);
-                Ok(Some(Some(DidSaveResult::new(false))))
+                Ok(None) // Notification pattern - ignore errors
             }
         }
     }

--- a/vim/autoload/yac_bridge.vim
+++ b/vim/autoload/yac_bridge.vim
@@ -312,32 +312,32 @@ endfunction
 
 function! yac_bridge#did_save(...) abort
   let text_content = a:0 > 0 ? a:1 : v:null
-  call s:request('did_save', {
+  call s:notify('did_save', {
     \   'file': expand('%:p'),
     \   'line': 0,
     \   'column': 0,
     \   'text': text_content
-    \ }, 's:handle_did_save_response')
+    \ })
 endfunction
 
 function! yac_bridge#did_change(...) abort
   let text_content = a:0 > 0 ? a:1 : join(getline(1, '$'), "\n")
-  call s:request('did_change', {
+  call s:notify('did_change', {
     \   'file': expand('%:p'),
     \   'line': 0,
     \   'column': 0,
     \   'text': text_content
-    \ }, 's:handle_did_change_response')
+    \ })
 endfunction
 
 function! yac_bridge#will_save(...) abort
   let save_reason = a:0 > 0 ? a:1 : 1
-  call s:request('will_save', {
+  call s:notify('will_save', {
     \   'file': expand('%:p'),
     \   'line': 0,
     \   'column': 0,
     \   'save_reason': save_reason
-    \ }, 's:handle_will_save_response')
+    \ })
 endfunction
 
 function! yac_bridge#will_save_wait_until(...) abort
@@ -351,11 +351,11 @@ function! yac_bridge#will_save_wait_until(...) abort
 endfunction
 
 function! yac_bridge#did_close() abort
-  call s:request('did_close', {
+  call s:notify('did_close', {
     \   'file': expand('%:p'),
     \   'line': 0,
     \   'column': 0
-    \ }, 's:handle_did_close_response')
+    \ })
 endfunction
 
 function! yac_bridge#file_search(...) abort
@@ -734,30 +734,6 @@ function! s:handle_file_open_response(channel, response) abort
   endif
 endfunction
 
-" did_save 响应处理器
-function! s:handle_did_save_response(channel, response) abort
-  " 通常没有响应，除非出错
-  if get(g:, 'lsp_bridge_debug', 0)
-    echom printf('YacDebug[RECV]: did_save response: %s', string(a:response))
-  endif
-endfunction
-
-" did_change 响应处理器
-function! s:handle_did_change_response(channel, response) abort
-  " 通常没有响应，除非出错
-  if get(g:, 'lsp_bridge_debug', 0)
-    echom printf('YacDebug[RECV]: did_change response: %s', string(a:response))
-  endif
-endfunction
-
-" will_save 响应处理器
-function! s:handle_will_save_response(channel, response) abort
-  " 通常没有响应，除非出错
-  if get(g:, 'lsp_bridge_debug', 0)
-    echom printf('YacDebug[RECV]: will_save response: %s', string(a:response))
-  endif
-endfunction
-
 " will_save_wait_until 响应处理器
 function! s:handle_will_save_wait_until_response(channel, response) abort
   if get(g:, 'lsp_bridge_debug', 0)
@@ -767,14 +743,6 @@ function! s:handle_will_save_wait_until_response(channel, response) abort
   " 可能返回文本编辑
   if has_key(a:response, 'edits')
     " 应用编辑
-  endif
-endfunction
-
-" did_close 响应处理器
-function! s:handle_did_close_response(channel, response) abort
-  " 通常没有响应，除非出错
-  if get(g:, 'lsp_bridge_debug', 0)
-    echom printf('YacDebug[RECV]: did_close response: %s', string(a:response))
   endif
 endfunction
 


### PR DESCRIPTION
Convert did_save, did_change, will_save, and did_close from request/response pattern to notification pattern as they don't require responses.

- Convert s:request() calls to s:notify() for fire-and-forget semantics
- Remove unused response handlers that only performed debug logging
- Keep will_save_wait_until and file_open as requests (they handle responses)
- Follows CLAUDE.md dual request/notification architecture pattern

Closes #59

Generated with [Claude Code](https://claude.ai/code)