### PR TITLE
fix: add missing direction parameter to call hierarchy commands

### DIFF
--- a/crates/lsp-bridge/src/handlers/common.rs
+++ b/crates/lsp-bridge/src/handlers/common.rs
@@ -36,3 +36,12 @@ pub fn file_path_to_uri(file_path: &str) -> Result<String> {
     let canonical = path.canonicalize()?;
     Ok(format!("file://{}", canonical.display()))
 }
+
+/// Convert URI to file path - used by handlers that need to convert LSP URIs back to paths
+pub fn uri_to_file_path(uri: &str) -> Result<String> {
+    let lsp_uri = lsp_types::Url::parse(uri)?;
+    let file_path = lsp_uri
+        .to_file_path()
+        .map_err(|_| anyhow::anyhow!("Invalid file URI"))?;
+    Ok(file_path.to_string_lossy().to_string())
+}

--- a/crates/lsp-bridge/src/handlers/file_search.rs
+++ b/crates/lsp-bridge/src/handlers/file_search.rs
@@ -264,7 +264,10 @@ impl FileSearchHandler {
                 || file_path.ends_with(&recent_file.trim_start_matches("./"))
         };
 
-        if let Some(position) = recent.iter().position(|recent_file| file_matches_recent(recent_file)) {
+        if let Some(position) = recent
+            .iter()
+            .position(|recent_file| file_matches_recent(recent_file))
+        {
             // Most recent file gets highest boost, decreasing for older files
             let recency_boost = RECENT_FILE_BASE_BOOST - (position as f64 * RECENT_FILE_DECAY_RATE);
             score += recency_boost;

--- a/vim/autoload/yac.vim
+++ b/vim/autoload/yac.vim
@@ -260,7 +260,8 @@ function! yac#call_hierarchy_incoming() abort
   call s:request('call_hierarchy_incoming', {
     \   'file': expand('%:p'),
     \   'line': line('.') - 1,
-    \   'column': col('.') - 1
+    \   'column': col('.') - 1,
+    \   'direction': 'incoming'
     \ }, 's:handle_call_hierarchy_response')
 endfunction
 
@@ -268,7 +269,8 @@ function! yac#call_hierarchy_outgoing() abort
   call s:request('call_hierarchy_outgoing', {
     \   'file': expand('%:p'),
     \   'line': line('.') - 1,
-    \   'column': col('.') - 1
+    \   'column': col('.') - 1,
+    \   'direction': 'outgoing'
     \ }, 's:handle_call_hierarchy_response')
 endfunction
 


### PR DESCRIPTION
Fixes #65

The YacCallHierarchyIncoming/YacCallHierarchyOutgoing commands were not displaying results because the Vim functions weren't passing the required 'direction' parameter that the Rust handler expected.

## Changes
- Add 'direction' parameter ('incoming'/'outgoing') to Vim call hierarchy functions
- Simplify CallHierarchyResponse structure to match Vim expectations
- Add uri_to_file_path helper function to convert LSP URIs back to file paths
- Remove unused Range struct and associated functions
- Fix clippy warning about unnecessary string conversion

Generated with [Claude Code](https://claude.ai/code)